### PR TITLE
Fix PlayerLoginEvent address

### DIFF
--- a/bukkit/src/main/kotlin/indi/nightfish/potato_ip_display/listener/PlayerJoinListener.kt
+++ b/bukkit/src/main/kotlin/indi/nightfish/potato_ip_display/listener/PlayerJoinListener.kt
@@ -20,18 +20,10 @@ class PlayerJoinListener : Listener {
 
         object : BukkitRunnable() {
                 override fun run() {
-                    val playerAddress = event.realAddress.hostAddress
+                    val playerAddress = event.address.hostAddress
                     val playerName = event.player.name
                     val ipParse = IpParseFactory.getIpParse(playerAddress)
-                    var result = ipParse.getProvince()
-
-                    if (result == "未知" || result == "") {
-                        result = ipParse.getCity()
-                        if (result == "未知" || result == "") {
-                            result = ipParse.getCountry()
-                        }
-                    }
-
+                    val result = ipParse.getFallback()
                     IpAttributeMap.playerIpAttributeMap[playerName] = result
                     plugin.log("Player named $playerName connect to proxy from ${ipParse.getProvince()}${ipParse.getCity()} ${ipParse.getISP()}")
                 }


### PR DESCRIPTION
Fixed: incorrect IP address when players connected from Velocity. This will cause the plugin to wrongly show an intranet attribution in the login messages.
*What's affected:* login messages, login console logs, player chat messages